### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/io.kopia.KopiaUI.json
+++ b/io.kopia.KopiaUI.json
@@ -19,8 +19,7 @@
         "--filesystem=host",
         "--filesystem=~/.var/app/",
         "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.kde.StatusNotifierWatcher",
-        "--own-name=org.kde.*"
+        "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules": [
         {


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 26.1.0
https://github.com/kopia/kopia/blob/1f70992d2ebe7e44c21e113375678e7372ca00bd/app/package.json#L119