### PR TITLE
Bump version to 0.18.2 and add github actions to build automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+on:
+    push:
+        branches: [master]
+    pull_request:
+name: CI
+jobs:
+    flatpak:
+        name: "Flatpak"
+        runs-on: ubuntu-24.04
+        container:
+            image: bilelmoussaoui/flatpak-github-actions:gnome-44
+            options: --privileged
+        strategy:
+            matrix:
+                arch: [x86_64, aarch64]
+            # Don't fail the whole workflow if one architecture fails
+            fail-fast: false
+        steps:
+        - uses: actions/checkout@v4
+        # Docker is required by the docker/setup-qemu-action which enables emulation
+        - name: Install deps
+          if: ${{ matrix.arch != 'x86_64' }}
+          run: |
+            dnf -y install docker
+        - name: Set up QEMU
+          if: ${{ matrix.arch != 'x86_64' }}
+          id: qemu
+          uses: docker/setup-qemu-action@v2
+          with:
+            platforms: ${{ matrix.arch }}
+        - uses: flatpak/flatpak-github-actions/flatpak-builder@master
+          with:
+            bundle: KopiaUI_${{ matrix.arch }}.flatpak
+            manifest-path: io.kopia.KopiaUI.json
+            cache-key: flatpak-builder-${{ github.sha }}
+            upload-artifact: true
+            arch: ${{ matrix.arch }}

--- a/io.kopia.KopiaUI.appdata.xml
+++ b/io.kopia.KopiaUI.appdata.xml
@@ -20,8 +20,11 @@
   </screenshots>
 	<launchable type="desktop-id">io.kopia.KopiaUI.desktop</launchable>
   <releases>
-    <release version="1.67.0" date="2024-06-14">
+    <release version="1.68.2" date="2024-11-15">
       <description></description>
+    </release>
+    <release version="1.67.0" date="2024-06-14">
+      <description/>
     </release>
     <release version="0.17.0" date="2024-04-16"/>
     <release version="0.16.1" date="2024-03-26"/>

--- a/io.kopia.KopiaUI.json
+++ b/io.kopia.KopiaUI.json
@@ -47,8 +47,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/kopia/kopia/releases/download/v0.17.0/kopia-ui_0.17.0_amd64.deb",
-                    "sha256": "7bf9efbc042126869c3a04def7323e177af0027fe5291cedc9e09e43a22da3e4",
+                    "url": "https://github.com/kopia/kopia/releases/download/v0.18.2/kopia-ui_0.18.2_amd64.deb",
+                    "sha256": "e56d50b0a0d2a456c697e1d15fc9fa445d97e442367beda988ec85dd256adec1",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/kopia/kopia/releases/latest",
@@ -64,8 +64,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/kopia/kopia/releases/download/v0.17.0/kopia-ui_0.17.0_arm64.deb",
-                    "sha256": "8ad79b3c8d5c71bde3e1306a08454ef1aeda4491f9bf7150c35470f3fbf13adf",
+                    "url": "https://github.com/kopia/kopia/releases/download/v0.18.2/kopia-ui_0.18.2_arm64.deb",
+                    "sha256": "fb3873cfc3fc1c64d84e8c7d357b484fdc35afed04ba5769ed12d5674324064b",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/kopia/kopia/releases/latest",
@@ -89,8 +89,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/rclone/rclone/releases/download/v1.67.0/rclone-v1.67.0-linux-amd64.zip",
-                    "sha256": "07c23d21a94d70113d949253478e13261c54d14d72023bb14d96a8da5f3e7722",
+                    "url": "https://github.com/rclone/rclone/releases/download/v1.68.2/rclone-v1.68.2-linux-amd64.zip",
+                    "sha256": "0e6fa18051e67fc600d803a2dcb10ddedb092247fc6eee61be97f64ec080a13c",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rclone/rclone/releases/latest",
@@ -106,8 +106,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/rclone/rclone/releases/download/v1.67.0/rclone-v1.67.0-linux-arm64.zip",
-                    "sha256": "2b44981a1a7d1f432c53c0f2f0b6bcdd410f6491c47dc55428fdac0b85c763f1",
+                    "url": "https://github.com/rclone/rclone/releases/download/v1.68.2/rclone-v1.68.2-linux-arm64.zip",
+                    "sha256": "c6e9d4cf9c88b279f6ad80cd5675daebc068e404890fa7e191412c1bc7a4ac5f",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/rclone/rclone/releases/latest",


### PR DESCRIPTION
There's probably more work to be done to clean this up for releases, maybe signing the bundle, and pushing to the repositories but at least in its current state this will build artifacts automatically and maybe make maintaining it easier.