### PR TITLE
Update Freedesktop & ElectronJS runtime to version 24.08

### DIFF
--- a/io.kopia.KopiaUI.json
+++ b/io.kopia.KopiaUI.json
@@ -1,9 +1,9 @@
 {
     "app-id": "io.kopia.KopiaUI",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "23.08",
+    "base-version": "24.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "kopia-ui",
     "separate-locales": false,


### PR DESCRIPTION
Freedesktop runtime version 23.08 reaching EOL in Oct 2025. 
https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/wikis/Releases